### PR TITLE
Line height checks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -537,6 +537,10 @@
     var lineHeightStr = style.lineHeight;
 
     if (lineHeightStr) {
+      if (lineHeightStr.indexOf('px') < 0) {
+        throw Error('The ellipsis container ' + elementName(el) + ' must have line-height set using px unit, found: ' + lineHeightStr);
+      }
+
       var lineHeight = parseInt(lineHeightStr, 10);
       if (lineHeight) {
         return lineHeight;


### PR DESCRIPTION
- include element's tagname/id/class when throwing
- require px unit, since that's already an implicit assumption
