### PR TITLE
Changed line height parsing method for subpixel calculations

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -177,6 +177,8 @@
           child.clampedHeight += child.gutterSpan * self.deltaHeight;
         }
 
+        // console.log('UNDERFLOW',overflow,underflow,child.clampedHeight,el)
+
         return child;
       }
     });
@@ -202,6 +204,7 @@
    */
 
   Ellipsis.prototype.getLineCount = function(el) {
+    // console.log('LINES',el.clientHeight,this.lineHeight,el.clientHeight/this.lineHeight,this.linesPerColumn,el)
     return (el.offsetWidth > this.columnWidth)
       ? getLinesFromRects(el, this.lineHeight)
       : lineCount(el.clientHeight, this.lineHeight);
@@ -467,7 +470,7 @@
    */
 
   function lineCount(height, lineHeight) {
-    return Math.floor(height / lineHeight);
+    return Math.round(height / lineHeight);
   }
 
   /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -541,7 +541,7 @@
         throw Error('The ellipsis container ' + elementName(el) + ' must have line-height set using px unit, found: ' + lineHeightStr);
       }
 
-      var lineHeight = parseInt(lineHeightStr, 10);
+      var lineHeight = parseFloat(lineHeightStr);
       if (lineHeight) {
         return lineHeight;
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -283,11 +283,11 @@
 
     // Use webkit line clamp
     // for webkit browsers.
-    if (vendor.webkit) {
-      child.el.style.webkitLineClamp = child.clampedLines;
-      child.el.style.display = '-webkit-box';
-      child.el.style.webkitBoxOrient = 'vertical';
-    }
+    // if (vendor.webkit) { // Always apply! doesn't hurt
+    child.el.style.webkitLineClamp = child.clampedLines;
+    child.el.style.display = '-webkit-box';
+    child.el.style.webkitBoxOrient = 'vertical';
+    // }
 
     if (this.shouldHideOverflow()) child.el.style.overflow = 'hidden';
 


### PR DESCRIPTION
As subpixel rendering has become prevalent, ftellipsis is starting to quite often fail to expand clipped elements to the correct height, as the `getLineHeight` func is using straight `parseInt` to parse the computed line height.

A way to get around this would be to simply switch to `parseFloat`. Or do you see a problem with that? Is there a reason for rounding the line height at this initial read state?